### PR TITLE
ci: Introduce zizmor for GitHub Actions security analysis

### DIFF
--- a/.cspell/dicts/base.txt
+++ b/.cspell/dicts/base.txt
@@ -3,3 +3,5 @@ cooldown
 lefthook
 shellcheck
 coderabbit
+zizmor
+zizmorcore

--- a/.github/workflows/check-empty.yml
+++ b/.github/workflows/check-empty.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions: {}
 
     steps:
       - name: Exit successfully

--- a/.github/workflows/check-github-workflow.yml
+++ b/.github/workflows/check-github-workflow.yml
@@ -24,7 +24,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
-          install_args: "actionlint shellcheck zizmor"
+          install_args: "actionlint shellcheck github:zizmorcore/zizmor"
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/check-github-workflow.yml
+++ b/.github/workflows/check-github-workflow.yml
@@ -13,7 +13,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/check-github-workflow.yml
+++ b/.github/workflows/check-github-workflow.yml
@@ -13,15 +13,18 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install mise and setup
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
-          install_args: "actionlint shellcheck"
+          install_args: "actionlint shellcheck zizmor"
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install mise and setup
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -9,9 +9,12 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install mise and setup
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/.github/workflows/dependabot-auto-approve-and-merge.yml
+++ b/.github/workflows/dependabot-auto-approve-and-merge.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Dependabot Auto Approve and Merge
         uses: 23prime/simple-dependabot-auto-approve-and-merge@1f3c00f396e7b680c81e3503aa6ecd3bef811cd6 # v1.0.0

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Sync upstream
         uses: 23prime/sync-upstream@6bdce9e135503a87b05c5836b0bc2b0d8db0786d # v1.0.0

--- a/README.md
+++ b/README.md
@@ -4,53 +4,58 @@ A Template for development with [mise](https://mise.jdx.dev).
 
 ## Getting started
 
-1. Clone this repository.
+1. Create new remote repository on GitHub.
+
+2. Clone this repository.
 
     ```bash
     git clone git@github.com:23prime/mise-template.git
     ```
 
-2. Copy the cloned repository to anywhere..
+3. Copy the cloned repository to anywhere.
 
     ```bash
-    cp -ar mise-template <your-repo-path>
+    cp -ar mise-template <new-repo-path>
     ```
 
-3. Into your repository.
+4. Into new repository.
 
     ```bash
-    cd <your-repo-path>
+    cd <new-repo-path>
     ```
 
-4. Rename remote repository to `upstream`.
+5. Rename remote repository to `upstream`.
 
     ```bash
     git remote rename origin upstream
     ```
 
-5. Create your remote repository as `origin` and set URL, push.
-
-    If you use GitHub CLI:
+6. Add new remote repository as `origin`.
 
     ```bash
-    gh repo create "<your-repo-name>" --private --source=. --remote=origin --push
+    git remote add origin <new-remote-url>
     ```
 
-    If you create repository on GitHub manually:
-
-    ```bash
-    git remote set-url origin <your-remote-url>
-    git push -u origin main
-    ```
-
-6. Check remote repositories.
+7. Check remote repositories.
 
     ```bash
     $ git remote -v
-    origin  <your-remote-url> (fetch)
-    origin  <your-remote-url> (push)
+    origin  <new-remote-url> (fetch)
+    origin  <new-remote-url> (push)
     upstream        git@github.com:23prime/mise-template.git (fetch)
     upstream        git@github.com:23prime/mise-template.git (push)
+    ```
+
+8. Push to `origin`.
+
+    ```bash
+    git push -u origin main
+    ```
+
+9. If you use GitHub CLI, set the default repository.
+
+    ```bash
+    gh repo set-default <new-repo-name>
     ```
 
 ## Merge from upstream

--- a/mise.toml
+++ b/mise.toml
@@ -20,6 +20,7 @@ shellcheck = "latest"
 # Other tools
 lefthook = "latest"
 cspell = "latest"
+"github:zizmorcore/zizmor" = "latest"
 
 
 # ================================================================
@@ -35,7 +36,7 @@ alias = "s"
 
 [tasks.fix]
 description = "Fix all issues"
-depends = ["md-fix"]
+depends = ["md-fix", "gh-fix"]
 alias = "f"
 
 [tasks.check]
@@ -60,9 +61,14 @@ run = "markdownlint-cli2 '**/*.md'"
 alias = "mc"
 
 # GitHub Actions
+[tasks.gh-fix]
+description = "Fix GitHub Actions workflows"
+run = "zizmor --fix=all .github/workflows/*.yml"
+alias = "ghf"
+
 [tasks.gh-check]
 description = "Check GitHub Actions workflows"
-run = "actionlint .github/workflows/*.yml"
+run = ["actionlint .github/workflows/*.yml", "zizmor .github/workflows/*.yml"]
 alias = "ghc"
 
 # Spell Check


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Introduce [zizmor](https://github.com/zizmorcore/zizmor) as a static analysis tool for GitHub Actions workflows, complementing the existing actionlint setup.

## Reason for change

Closes #6.

actionlint covers syntax and logic correctness, while zizmor focuses on security findings (unpinned actions, excessive permissions, credential leakage, etc.). Both tools serve different purposes and work well together.

## Changes

- `mise.toml`: Add zizmor tool, add `gh-fix` task (`zizmor --fix=all`), update `gh-check` to run both actionlint and zizmor, add `gh-fix` to `fix` task dependencies
- `check-github-workflow.yml`: Add zizmor to `install_args`
- All workflows: Add `persist-credentials: false` to checkout steps (`artipacked` finding)
- `check-empty.yml`, `check-github-workflow.yml`, `check-spelling.yml`: Add `permissions: {}` to jobs (`excessive-permissions` finding)

## Notes

- `gh-fix` uses `--fix=all` (not the default `safe` mode) because the `artipacked` auto-fix is classified as unsafe by zizmor, but is safe for this repo's read-only checkout usage.