### PR TITLE
feat: Add setup script to initialize a new repository from this template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ A Template for development with [mise](https://mise.jdx.dev).
 
 ## Getting started
 
+### Using setup script
+
+1. Create new remote repository on GitHub.
+
+2. Run the setup script.
+
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/23prime/mise-template/main/setup.sh | bash -s -- <new-remote-url> [new-repo-name]
+    ```
+
+    - `<new-remote-url>` — remote URL of the pre-created repository
+    - `[new-repo-name]` — optional; defaults to the repository name derived from the URL
+
+### Manual steps
+
 1. Create new remote repository on GitHub.
 
 2. Clone this repository.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEMPLATE_REPO="git@github.com:23prime/mise-template.git"
+
+usage() {
+  echo "Usage: setup.sh <remote-url> [repo-name]"
+  echo ""
+  echo "  <remote-url>  Remote URL of the pre-created repository to register as origin"
+  echo "  [repo-name]   Repository name (default: derived from <remote-url>)"
+  exit 1
+}
+
+# ----------------------------------------------------------------
+# Argument parsing
+# ----------------------------------------------------------------
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+REMOTE_URL="$1"
+REPO_NAME="${2:-}"
+
+if [[ -z "$REPO_NAME" ]]; then
+  REPO_NAME="$(basename "$REMOTE_URL" .git)"
+fi
+
+# ----------------------------------------------------------------
+# Prerequisite checks
+# ----------------------------------------------------------------
+for cmd in git gh; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: '$cmd' is not installed or not in PATH." >&2
+    exit 1
+  fi
+done
+
+echo "Checking remote repository '$REMOTE_URL'..."
+if ! git ls-remote "$REMOTE_URL" &>/dev/null; then
+  echo "Error: Cannot access remote repository '$REMOTE_URL'." >&2
+  echo "Make sure the repository exists and you have access to it." >&2
+  exit 1
+fi
+
+# ----------------------------------------------------------------
+# Setup
+# ----------------------------------------------------------------
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Cloning template repository..."
+git clone "$TEMPLATE_REPO" "$TMPDIR/mise-template"
+
+echo "Copying to '$REPO_NAME'..."
+cp -ar "$TMPDIR/mise-template" "$REPO_NAME"
+
+cd "$REPO_NAME"
+
+echo "Renaming 'origin' to 'upstream'..."
+git remote rename origin upstream
+
+echo "Adding '$REMOTE_URL' as 'origin'..."
+git remote add origin "$REMOTE_URL"
+
+echo "Pushing to origin..."
+git push -u origin main
+
+echo "Setting default repository for gh CLI..."
+gh repo set-default "$REPO_NAME"
+
+echo ""
+echo "Done! Your repository '$REPO_NAME' is ready."
+echo "Run 'cd $REPO_NAME' to enter the repository."

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TEMPLATE_REPO="git@github.com:23prime/mise-template.git"
+TEMPLATE_REPO="${TEMPLATE_REPO:-https://github.com/23prime/mise-template.git}"
 
 usage() {
   echo "Usage: setup.sh <remote-url> [repo-name]"

--- a/setup.sh
+++ b/setup.sh
@@ -45,14 +45,22 @@ fi
 # ----------------------------------------------------------------
 # Setup
 # ----------------------------------------------------------------
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
+SETUP_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/setup.XXXXXXXXXX")"
+if [[ -z "${SETUP_TMPDIR:-}" || ! -d "$SETUP_TMPDIR" ]]; then
+  echo "Error: Failed to create temporary directory." >&2
+  exit 1
+fi
+trap 'rm -rf "$SETUP_TMPDIR"' EXIT
 
 echo "Cloning template repository..."
-git clone "$TEMPLATE_REPO" "$TMPDIR/mise-template"
+git clone "$TEMPLATE_REPO" "$SETUP_TMPDIR/mise-template"
 
 echo "Copying to '$REPO_NAME'..."
-cp -ar "$TMPDIR/mise-template" "$REPO_NAME"
+if [[ -e "$REPO_NAME" ]]; then
+  echo "Error: Target path '$REPO_NAME' already exists. Please remove it or choose a different repo name." >&2
+  exit 1
+fi
+cp -ar "$SETUP_TMPDIR/mise-template" "$REPO_NAME"
 
 cd "$REPO_NAME"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Closes #8.

Add `setup.sh` to automate the Getting Started steps for initializing a new repository from this template.

## Changes

- `setup.sh`: New script that automates clone → copy → remote setup → push → `gh repo set-default`
  - Takes `<remote-url>` (required) and `[repo-name]` (optional, derived from URL if omitted)
  - Checks for required commands (`git`, `gh`) and remote repository accessibility upfront
  - Uses a temp directory for cloning to avoid conflicts with existing directories
- `README.md`: Add "Using setup script" section above the existing manual steps

## Notes

- Remote repository must be created in advance
- Script is designed to be fetched and piped into bash with arguments