### PR TITLE
ci: Add mise auto-upgrade workflow

### DIFF
--- a/.github/workflows/mise-upgrade.yml
+++ b/.github/workflows/mise-upgrade.yml
@@ -10,6 +10,8 @@ permissions: {}
 jobs:
   list-outdated:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       tools: ${{ steps.list.outputs.tools }}
     steps:

--- a/.github/workflows/mise-upgrade.yml
+++ b/.github/workflows/mise-upgrade.yml
@@ -1,0 +1,52 @@
+name: mise upgrade
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Every day
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  list-outdated:
+    runs-on: ubuntu-latest
+    outputs:
+      tools: ${{ steps.list.outputs.tools }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: List outdated tools
+        id: list
+        run: |
+          tools=$(mise outdated --bump --local --json | jq -c '[.[].name]')
+          echo "tools=${tools}" >> "$GITHUB_OUTPUT"
+
+  upgrade:
+    needs: list-outdated
+    if: needs.list-outdated.outputs.tools != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      matrix:
+        tool: ${{ fromJson(needs.list-outdated.outputs.tools) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: 23prime/mise-upgrade-action@cafd0db78c71bfa861f77f68e6076901caa73f45 # v1.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tool: ${{ matrix.tool }}
+          install-before: "3d"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Add a GitHub Actions workflow that automatically upgrades mise-managed tools and opens a pull request per tool.

## Reason for change

Automate dependency upgrades for mise-managed tools to reduce manual maintenance overhead.

## Changes

- Add `.github/workflows/mise-upgrade.yml`
  - Runs daily at UTC 00:00 (JST 09:00) and on `workflow_dispatch`
  - `list-outdated` job detects outdated tools via `mise outdated --bump --local --json`
  - `upgrade` job runs in a matrix (one job per tool) using `23prime/mise-upgrade-action`
  - Respects `install-before: "3d"` to avoid immediately-released versions

## Notes

Uses `23prime/mise-upgrade-action@cafd0db78c71bfa861f77f68e6076901caa73f45` (v1.0.1).