### PR TITLE
ci: add workflow concurrency and document permissions

### DIFF
--- a/.github/workflows/check-empty.yml
+++ b/.github/workflows/check-empty.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/check-github-workflow.yml
+++ b/.github/workflows/check-github-workflow.yml
@@ -12,6 +12,10 @@ on:
       - ".github/workflows/*.yml"
       - "mise.lock"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -16,13 +16,17 @@ on:
       - ".markdownlint-cli2.jsonc"
       - "mise.lock"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
   check:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # push auto-fix commits
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/dependabot-auto-approve-and-merge.yml
+++ b/.github/workflows/dependabot-auto-approve-and-merge.yml
@@ -4,14 +4,18 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
   approve-and-merge:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # merge the PR
+      pull-requests: write # approve the PR
 
     if: github.event.pull_request.user.login == 'dependabot[bot]'
 

--- a/.github/workflows/mise-upgrade.yml
+++ b/.github/workflows/mise-upgrade.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 0 * * *" # Every day
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -5,14 +5,18 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
   sync-upstream:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # push synced commits
+      pull-requests: write # create the sync PR
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/mise.toml
+++ b/mise.toml
@@ -78,7 +78,7 @@ alias = "ghf"
 description = "Check GitHub Actions workflows"
 run = [
   "actionlint .github/workflows/*.yml",
-  "zizmor . --persona=pedantic --min-severity=medium",
+  "zizmor . --persona=pedantic --min-severity=low",
 ]
 alias = "ghc"
 


### PR DESCRIPTION
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

zizmor の `gh-check` を `--min-severity=low` に下げ、新たに表面化した `concurrency-limits`（8 件）と `undocumented-permissions`（3 件）の指摘を解消した。

## Reason for change

`--persona=pedantic` で網羅を広げているのに `--min-severity=medium` で pedantic 由来の low 指摘を切り捨てており、pedantic を活かしきれていなかった。下限を `low` に下げてより多くの問題を拾うようにし、その結果出た指摘に対応した。

## Changes

- `mise.toml`: `gh-check` の zizmor を `--min-severity=medium` → `low`
- 全ワークフローに `concurrency:` ブロックを追加
  - read-only チェック（check-empty / check-github-workflow / check-secrets / check-spelling）: `cancel-in-progress: true`
  - 書き込み系（check-markdown / dependabot-auto-approve-and-merge / mise-upgrade / sync-upstream）: `cancel-in-progress: false`（push/merge の途中キャンセルを避けるため）
- 各 `permissions` に理由コメントを付与（check-markdown / dependabot-auto-approve-and-merge / sync-upstream）

## Notes

`gh-check` 実行で actionlint・zizmor ともに `No findings to report`（残り 9 件は既存の意図的 ignore）。