### PR TITLE
chore: add .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,9 @@
 # See:
 # - https://docs.coderabbit.ai/reference/configuration
 # - https://docs.coderabbit.ai/configuration/path-instructions
+# - https://docs.coderabbit.ai/configuration/configuration-inheritance
+
+inheritance: true
 
 reviews:
   path_filters:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+# See:
+# - https://docs.coderabbit.ai/reference/configuration
+# - https://docs.coderabbit.ai/configuration/path-instructions
+
+reviews:
+  path_filters:
+    - "!.cspell/dicts/**"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Add `.coderabbit.yaml` with path filters configured.

## Reason for change

CodeRabbit was not yet configured for this repository. This adds a minimal config to exclude non-code data files from review.

## Changes

- Add `.coderabbit.yaml`
- Set `reviews.path_filters` to exclude `.cspell/dicts/**` (cspell word list data, not code)

## Notes

`mise.lock` is not excluded explicitly, since CodeRabbit's default ignored paths already cover generic lock files (`!**/*.lock`).

Closes #47
