### PR TITLE
ci: add workflow to detect and fix mise.lock drift

### DIFF
--- a/.github/workflows/check-mise-lock.yml
+++ b/.github/workflows/check-mise-lock.yml
@@ -1,0 +1,51 @@
+name: Check mise lock
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "mise.toml"
+      - "mise.lock"
+      - ".github/workflows/check-mise-lock.yml"
+  pull_request:
+    paths:
+      - "mise.toml"
+      - "mise.lock"
+      - ".github/workflows/check-mise-lock.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push auto-fix commits
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: false
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fix
+        run: mise run lock-fix
+
+      - name: Commit and Push
+        uses: 23prime/simple-commit-and-push@15fb653b9591afde3bffb82a906a9af2aede1616 # v1.0.0
+        with:
+          commit-message: "Auto fix by workflow"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check
+        run: mise run lock-check

--- a/.github/workflows/check-mise-lock.yml
+++ b/.github/workflows/check-mise-lock.yml
@@ -1,5 +1,12 @@
 name: Check mise lock
 
+# Note:
+# Renovate's mise manager can update mise.lock itself, but doing so runs `mise lock`,
+# which Renovate treats as an unsafe execution requiring `allowedUnsafeExecutions`
+# in the bot/admin config. That's a self-hosted-only setting, unavailable to the
+# Mend-hosted Renovate GitHub App this repo uses, so Renovate PRs only bump mise.toml
+# and leave mise.lock stale. This workflow re-locks it whenever that drift appears.
+
 on:
   push:
     branches:

--- a/mise.lock
+++ b/mise.lock
@@ -143,7 +143,7 @@ url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/43
 provenance = "github-attestations"
 
 [[tools.markdownlint-cli2]]
-version = "0.22.1"
+version = "0.23.0"
 backend = "npm:markdownlint-cli2"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -44,12 +44,12 @@ alias = "s"
 
 [tasks.fix]
 description = "Fix all issues"
-depends = ["md-fix", "gh-fix"]
+depends = ["md-fix", "gh-fix", "lock-fix"]
 alias = "f"
 
 [tasks.check]
 description = "Check for all issues"
-depends = ["md-check", "gh-check", "spell-check", "secret-check-all"]
+depends = ["md-check", "gh-check", "spell-check", "secret-check-all", "lock-check"]
 alias = "c"
 
 [tasks.fix-and-check]
@@ -98,3 +98,14 @@ alias = "scc"
 description = "Check for leaked secrets"
 run = "betterleaks git --redact --no-banner"
 alias = "sca"
+
+# mise lock
+[tasks.lock-fix]
+description = "Update mise.lock"
+run = "mise lock"
+alias = "lf"
+
+[tasks.lock-check]
+description = "Check mise.lock is up to date"
+run = ["mise lock", "git diff --exit-code -- mise.lock"]
+alias = "lc"

--- a/mise.toml
+++ b/mise.toml
@@ -44,12 +44,12 @@ alias = "s"
 
 [tasks.fix]
 description = "Fix all issues"
-depends = ["md-fix", "gh-fix", "lock-fix"]
+depends = ["md-fix", "gh-fix"]
 alias = "f"
 
 [tasks.check]
 description = "Check for all issues"
-depends = ["md-check", "gh-check", "spell-check", "secret-check-all", "lock-check"]
+depends = ["md-check", "gh-check", "spell-check", "secret-check-all"]
 alias = "c"
 
 [tasks.fix-and-check]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Add a CI workflow that keeps `mise.lock` in sync with `mise.toml`, and re-lock the currently drifted `mise.lock`.

## Reason for change

Renovate's mise manager only rewrites `mise.toml`; it does not run `mise lock`. As a result `mise.lock` had silently fallen out of sync (e.g. `markdownlint-cli2` stayed at `0.22.1` in the lockfile after `mise.toml` was bumped to `0.23.0`). `postUpgradeTasks` was considered but is a self-hosted-only Renovate feature (`allowedCommands` must be set in the bot/admin config), which doesn't apply to the Mend-hosted Renovate GitHub App used here.

## Changes

- `mise.toml`: add `lock-fix` / `lock-check` tasks and wire them into `fix` / `check`
- `.github/workflows/check-mise-lock.yml`: on changes to `mise.toml` / `mise.lock`, run `mise lock`, auto-commit and push any diff, then verify the lockfile is clean
- `mise.lock`: re-lock to pick up the already-drifted `markdownlint-cli2` version

## Notes

Since Renovate PRs have `automerge: true`, this lets lockfile drift get fixed and pushed automatically without manual intervention.