### PR TITLE
ci: Check out the PR head so auto-fix commits can be pushed

### DIFF
--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -35,6 +35,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # pull_request checks out a shallow merge commit by default, and its parents are missing
+          # locally, so pushing the auto-fix commit to the PR branch is rejected as non-fast-forward.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install mise and setup
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1

--- a/.github/workflows/check-mise-lock.yml
+++ b/.github/workflows/check-mise-lock.yml
@@ -40,6 +40,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # pull_request checks out a shallow merge commit by default, and its parents are missing
+          # locally, so pushing the auto-fix commit to the PR branch is rejected as non-fast-forward.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install mise
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Closes #60.

`check-mise-lock.yml` and `check-markdown.yml` now check out the pull request head SHA, so the auto-fix commit they produce can actually be pushed to the PR branch.

## Reason for change

On `pull_request` events `actions/checkout` defaults to a shallow (`--depth=1`) fetch of the ephemeral merge ref. Only the merge commit itself is present locally; its parents — including the PR branch tip — are grafted away.

`23prime/simple-commit-and-push` runs `git push origin HEAD:${{ github.head_ref || github.ref_name }}`. Git cannot find the advertised remote tip in the local object store, so it cannot establish a fast-forward and rejects the push:

```text
 ! [rejected]        HEAD -> sync-upstream-30227982611 (fetch first)
error: failed to push some refs
```

This means the `pull_request` path of both workflows has never been able to push an auto-fix commit — the failure only surfaces once drift actually appears. It was observed in the derived repository `23prime/web-app-template`, PR #101, run `30227996001` (identical failure across all three attempts, so not a transient race).

Checking out the head SHA makes `HEAD` equal to the remote branch tip, so the auto-fix commit is a plain fast-forward.

## Changes

Both `.github/workflows/check-mise-lock.yml` and `.github/workflows/check-markdown.yml`:

```yaml
      - name: Checkout
        uses: actions/checkout@... # v7.0.1
        with:
          persist-credentials: false
          # pull_request checks out a shallow merge commit by default, and its parents are missing
          # locally, so pushing the auto-fix commit to the PR branch is rejected as non-fast-forward.
          ref: ${{ github.event.pull_request.head.sha || github.sha }}
```

`check-markdown.yml` carries the identical latent bug — it has simply never produced an auto-fix change on a pull request — so it gets the same fix.

`persist-credentials: false` is retained in both; it is there to satisfy zizmor.

## Notes

### Why the head SHA rather than `github.head_ref`

`ref: ${{ github.head_ref }}` also works for same-repository PRs, but for fork PRs it names a branch that does not exist in the base repository, so the checkout step itself fails — including in the common no-drift case that succeeds today. GitHub keeps `refs/pull/N/head` in the base repository, so the head SHA stays fetchable for fork PRs.

On `push` events `github.event.pull_request` is null, so the expression falls back to `github.sha` and that path is unchanged.

### Verification

`mise run gh-check` (actionlint + zizmor `--persona=pedantic --min-severity=low`) passes, as do `mise run fix` and `mise run check`.

This PR edits `.github/workflows/check-mise-lock.yml`, which that workflow's own `paths` filter matches, so the workflow runs against this PR. CI installs a newer mise than the local environment (`2026.7.14` vs `2026.7.12`), so `mise run lock-fix` may produce drift here and exercise the auto-fix push for real. No artificial staleness was introduced; if the drift does not appear, the end-to-end path simply remains unproven rather than being forced.

### Accepted trade-offs

- **Validation now targets the PR head, not the merge result.** Checking out the merge ref is what made the push impossible, so this is inherent to the fix: pushing from the merge ref would inject a merge commit into the PR branch. Since the repository's ruleset sets `strict_required_status_checks_policy: false`, a PR that is behind `main` is no longer validated against the merged state.
- **Fork PRs still cannot push.** `GITHUB_TOKEN` is read-only for fork PRs, so the push fails whenever drift exists. That was already true before this change; the no-drift path keeps working.

### Known follow-up

Pushes made with `GITHUB_TOKEN` do not trigger new workflow runs, so after an auto-fix commit lands, the new head SHA carries no `check` status and the required status check stays pending. Resolving that needs a PAT or GitHub App token, which is out of scope here and worth its own issue.

Separately, the mise version is not pinned in CI, so this class of `mise.lock` drift will keep recurring — also noted in #60 as out of scope.
